### PR TITLE
feat(api): return branch name in issue creation response

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -71,12 +71,20 @@ mod tests {
 
     #[test]
     fn test_get_api_key_failure() {
+        let original_key = std::env::var("LINEAR_API_KEY").ok();
         unsafe {
             std::env::remove_var("LINEAR_API_KEY");
         }
         let result = get_api_key();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("LINEAR_API_KEY"));
+
+        // Restore original key if it existed
+        if let Some(key) = original_key {
+            unsafe {
+                std::env::set_var("LINEAR_API_KEY", key);
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Users can now access generated branch names for workflow automation
- Added branch_name field to Issue struct with Linear's branchName mapping
- Enhanced create command output to display branch information
- Improves developer experience by exposing git branch context

Closes #1 